### PR TITLE
Fix offline service delete data method

### DIFF
--- a/logic/model/data-identifier.js
+++ b/logic/model/data-identifier.js
@@ -1,18 +1,25 @@
 var Montage = require("montage").Montage;
 
 /**
- * A DataIdentifier represents a universal identifier for an object managed by Montage Data.
- * It provides the support for uniquing in a DataService. Wether an object extists in
- * one or more local DataService in an Application or in a remote one, a DataIdentifier
- * encapsulate the information needed to uniquely identify an object, like a primary key in a database.
- * A DataIdentifier has a URL representation, which is conceptually aligned with the notion of resource:
- * It should have:
- * - a host/source/origin: where the data come from. Automatically generated primary keys
- *  exists in only one environment - Dev, test, prod, etc...,
- * (a user's authorization (if any necessary) should be left to be resolved a client receiving the identifier,
- * only people authenticated and authorized would be able to get it and that happens at DataService level)
+ * A DataIdentifier represents a universal identifier for an object managed by
+ * Montage Data.  It provides the support for uniquing in a DataService.
+ * Whether an object exists in one or more local DataServices in an Application
+ * or in a remote one, a DataIdentifier encapsulates the information needed to
+ * uniquely identify an object, like a primary key in a database.  A DataIdentifier
+ * has a URL representation, which is conceptually aligned with the notion of
+ * resource. It should have:
+ *
+ * - a host/source/origin: where the data come from. Automatically generated
+ * primary keys exists in only one environment - Dev, test, prod, etc...,
+ * (a user's authorization (if any necessary) should be left to be resolved
+ * by a client receiving the identifier, only people authenticated and authorized
+ * would be able to get it and that happens at DataService level)
+ *
  * - a type
- * - a primary key. This could be a combination of property/value, but it needs to be serializable as a valid url
+ *
+ * - a primary key. This could be a combination of property/value, but it needs
+ * to be serializable as a valid url
+ *
  * Exact details are not exposed and may vary per specific DataService or RawDataService
  *
  * @class
@@ -30,7 +37,7 @@ exports.DataIdentifier = Montage.specialize(/** @lends DataIdentifier.prototype 
     },
 
     /**
-     * The ObjectDescriptor associated witH a dataIdentifier
+     * The ObjectDescriptor associated with a dataIdentifier
      *
      * @type {ObjectDescriptor}
      */
@@ -39,36 +46,33 @@ exports.DataIdentifier = Montage.specialize(/** @lends DataIdentifier.prototype 
     },
 
     /**
-     * Wether a DataIdentifier is persistent/final vs temporary when created client side
+     * Whether a DataIdentifier is persistent/final vs temporary when created
+     * client side.
      *
-     * @type {ObjectDescriptor}
+     * @type {boolean}
      */
     isPersistent: {
         value: false
     },
 
-    /**
-     * Wether a DataIdentifier is persistent/final vs temporary when created client side
-     *
-     * @type {ObjectDescriptor}
-     */
     _identifier: {
         value: false
     },
 
     _url: {
-        value: false
+        value: undefined
     },
-  /**
+
+    /**
      * The url representation of a dataIdentifier
      *
-     * @type {ObjectDescriptor}
+     * @type {string}
      */
     url: {
-        get: function() {
+        get: function () {
             return this._url;
         },
-        set: function(value) {
+        set: function (value) {
             return this._url = value;
         }
     }

--- a/logic/service/data-service.js
+++ b/logic/service/data-service.js
@@ -1437,7 +1437,7 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
      * same child service.
      *
      * For each operation not handled by a child service, the default
-     * implemenation calls a method named `performFooOfflineOperation()`, if
+     * implementation calls a method named `performFooOfflineOperation()`, if
      * such a method exists in this service where `foo` is the operation's
      * [data type]{@link DataOperation#dataType}. If no such method exists,
      * [readOfflineOperation()]{@link DataService#readOfflineOperation} is
@@ -1504,7 +1504,7 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
             var self = this,
                 operationType = operation.type,
                 tableSchema, foreignKeys,
-                k, countK, kOnlinePrimaryKey;
+                k, countK, kOnlinePrimaryKey, kForeignKey;
 
             if(this.offlineService) {
                 tableSchema = this.offlineService.schema[operationType];
@@ -1535,7 +1535,7 @@ exports.DataService = Montage.specialize(/** @lends DataService.prototype */ {
         value: function(operation) {
             // TODO: Remove support for operation.type once all child services
             // have been updated to provide an operation.dataType instead.
-            var type = operation.dataType || operation.type;
+            var type = operation.dataType || operation.type,
                 method = type && this[this._getOfflineOperationMethodName(type)];
             return typeof(method) === "function" ? method.call(this, operation) :
                                                    this.performOfflineOperation(operation);

--- a/logic/service/offline-service.js
+++ b/logic/service/offline-service.js
@@ -568,11 +568,11 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
 
     readOfflineOperations: {
         value: function (/* operationMapToService */) {
-            var operationTable = this.operationTable,
-                myDB = this._db;
+            var self = this;
             return new Promise(function (resolve, reject) {
+                var myDB = self._db;
                 myDB.open().then(function (/* db */) {
-                    operationTable.where("operation").anyOf("create", "update", "delete").toArray(function (offlineOperations) {
+                    self.operationTable.where("operation").anyOf("create", "update", "delete").toArray(function (offlineOperations) {
                         resolve(offlineOperations);
                     }).catch(function (e) {
                         console.log(selector.type + ": performOfflineSelectorChanges failed", e);
@@ -587,7 +587,7 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
     performOfflineSelectorChanges: {
         value: function (selector, rawDataArray, updateOperationArray, offlineObjectsToClear) {
             var myDB = this._db,
-                operationTable = this.operationTable,
+                self = this,
                 clonedRawDataArray = rawDataArray.slice(0), // why clone twice?
                 clonedUpdateOperationArray = updateOperationArray.slice(0),
                 clonedOfflineObjectsToClear = offlineObjectsToClear.slice(0);
@@ -596,7 +596,8 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
             .open()
             .then(function (db) {
 
-                var table = db[selector.type];
+                var table = db[selector.type],
+                    operationTable = self.operationTable;
 
             //Transaction:
                 //Objects to put:
@@ -859,11 +860,7 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
      */
     deleteData: {
         value: function (objects, type, context) {
-            var self = this,
-                changesPropertyName = this.changesPropertyName,
-                typePropertyName = this.typePropertyName,
-                operationPropertyName = this.operationPropertyName,
-                operationDeleteName = this.operationDeleteName;
+            var self = this;
 
             if(!objects || objects.length === 0) return Dexie.Promise.resolve();
 
@@ -876,6 +873,10 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                 dataID = self.dataIDPropertyName,
                 lastModifiedPropertyName = self.lastModifiedPropertyName,
                 lastModified = Date.now(),
+                changesPropertyName = self.changesPropertyName,
+                typePropertyName = self.typePropertyName,
+                operationPropertyName = self.operationPropertyName,
+                operationDeleteName = self.operationDeleteName,
                 updateDataPromises = [];
 
                 myDB.open().then(function (db) {

--- a/logic/service/offline-service.js
+++ b/logic/service/offline-service.js
@@ -36,7 +36,6 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
         value: void 0
     },
 
-
      /**
      * Main initialiation method
      *
@@ -386,7 +385,7 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                             resultPromise = wherePromise
                                             .and(function (aRecord) {
                                                 var result = true;
-                                                for(var i=0, iKey, iValue, iKeyMatchValue;(iKey = whereProperties[i]);i++) {
+                                                for(var i=0, iKey, iValue, iKeyMatchValue, iOrValue;(iKey = whereProperties[i]);i++) {
                                                     iValue = criteria[iKey];
                                                     iKeyMatchValue = false;
                                                     if(Array.isArray(iValue)) {
@@ -496,16 +495,14 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
      *                                   call that is invoking this method.
      */
 
-    //writeOfflineData/readOfflineOperatio
+    //writeOfflineData/readOfflineOperation
 
     writeOfflineData: {
         value: function (rawDataArray, selector) {
 
             var self = this,
-                db = this._db,
                 tableName = selector.type,
                 table = this.tableNamed(tableName),
-                lastUpdatedTable = this.operationTable,
                 clonedArray = [],
                 i,countI,iRawData, iLastUpdated,
                 lastUpdated = Date.now(),
@@ -513,19 +510,15 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                 dataID = this.dataIDPropertyName,
                 primaryKey = table.schema.primKey.name,
                 lastUpdatedPropertyName = this.lastFetchedPropertyName,
-                j, countJ, jRawData,
+                j, jRawData,
                 rawDataMapByPrimaryKey,
                 offlineObjectsToClear = [],
                 rawDataStream = new DataStream();
 
                 rawDataStream.selector = selector;
 
-
-            primaryKey = table.schema.primKey.name;
-
-
             //Make a clone of the array and create the record to track the online Last Updated date
-            for(i=0, countI = rawDataArray.length;i<countI;i++) {
+            for(i=0, countI = rawDataArray.length; i<countI; i++) {
                 if((iRawData = rawDataArray[i])) {
                     clonedArray.push(iRawData);
 
@@ -542,10 +535,11 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
             return this.fetchData(selector,rawDataStream).then(function (offlineSelectedRecords) {
                 // 2) Loop on offline results and if we can't find it in the recent rawDataArray:
                 //    2.0) Remove the non-matching record so it doesn't show up in results
-                //         if that query were immediatrely done next as offline.
+                //         if that query were immediately done next as offline.
                 // Not ideal as we're going to do at worse a full lookup of rawDataArray, every iteration
                 for(var i=0, countI = offlineSelectedRecords.length, iRecord, iRecordPrimaryKey;(iRecord = offlineSelectedRecords[i]);i++) {
                     iRecordPrimaryKey = iRecord[self.dataIDPropertyName];
+                    // move above loop? remove conditional? saves case where countI = 0?
                     if(!rawDataMapByPrimaryKey) {
                         rawDataMapByPrimaryKey = new Map();
                         for(j=0;(jRawData = rawDataArray[j]);j++) {
@@ -573,23 +567,17 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
     },
 
     readOfflineOperations: {
-        value: function (operationMapToService) {
-            var operationTable,
-                self = this;
-
+        value: function (/* operationMapToService */) {
+            var operationTable = this.operationTable,
+                myDB = this._db;
             return new Promise(function (resolve, reject) {
-                var myDB = self._db;
-
-                myDB
-                .open()
-                .then(function (db) {
-                    self.operationTable.where("operation").anyOf("create","update","delete")
-                    .toArray(function (offlineOperations) {
-                            resolve(offlineOperations);
-                    }).catch(function(e) {
-                            console.log(selector.type + ": performOfflineSelectorChanges failed",e);
-                            console.error(e);
-                            reject(e);
+                myDB.open().then(function (/* db */) {
+                    operationTable.where("operation").anyOf("create", "update", "delete").toArray(function (offlineOperations) {
+                        resolve(offlineOperations);
+                    }).catch(function (e) {
+                        console.log(selector.type + ": performOfflineSelectorChanges failed", e);
+                        console.error(e);
+                        reject(e);
                     });
                 });
             });
@@ -599,8 +587,8 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
     performOfflineSelectorChanges: {
         value: function (selector, rawDataArray, updateOperationArray, offlineObjectsToClear) {
             var myDB = this._db,
-                self = this,
-                clonedRawDataArray = rawDataArray.slice(0),
+                operationTable = this.operationTable,
+                clonedRawDataArray = rawDataArray.slice(0), // why clone twice?
                 clonedUpdateOperationArray = updateOperationArray.slice(0),
                 clonedOfflineObjectsToClear = offlineObjectsToClear.slice(0);
 
@@ -608,8 +596,8 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
             .open()
             .then(function (db) {
 
-                var table = db[selector.type],
-                    operationTable = self.operationTable;
+                var table = db[selector.type];
+
             //Transaction:
                 //Objects to put:
                 //      rawDataArray
@@ -628,7 +616,7 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                 }).then(function(value) {
                     //console.log(selector.type + ": performOfflineSelectorChanges succesful: "+rawDataArray.length+" rawDataArray, "+clonedUpdateOperationArray.length+" updateOperationArray");
                 }).catch(function(e) {
-                        console.log(selector.type + ": performOfflineSelectorChanges failed",e);
+                        console.log(selector.type + ": performOfflineSelectorChanges failed", e);
                         console.error(e);
                 });
             });
@@ -736,7 +724,7 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                                 //     console.log(offlinePrimaryKeys);
                                 // });
 
-                                //Once this succedded, we need to add our temporary primary keys bookeeping:
+                                //Once this succedded, we need to add our temporary primary keys bookkeeping:
                                 //Register potential temporary primaryKeys
                                 self.registerOfflinePrimaryKeyDependenciesForData(objects, table.name, primaryKey)
                                 .then(function() {
@@ -871,7 +859,12 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
      */
     deleteData: {
         value: function (objects, type, context) {
-            var self = this;
+            var self = this,
+                changesPropertyName = this.changesPropertyName,
+                typePropertyName = this.typePropertyName,
+                operationPropertyName = this.operationPropertyName,
+                operationDeleteName = this.operationDeleteName;
+
             if(!objects || objects.length === 0) return Dexie.Promise.resolve();
 
             return new Promise(function (resolve, reject) {
@@ -879,23 +872,18 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                 table = self.tableNamed(type),
                 operationTable = self.operationTable,
                 clonedObjects = objects.slice(0),
-                operations = [],
                 primaryKey = table.schema.primKey.name,
                 dataID = self.dataIDPropertyName,
                 lastModifiedPropertyName = self.lastModifiedPropertyName,
                 lastModified = Date.now(),
-                updateDataPromises = [],
-                typePropertyName = this.typePropertyName,
-                changesPropertyName = this.changesPropertyName,
-                operationPropertyName = this.operationPropertyName,
-                operationDeleteName = this.operationDeleteName;
+                updateDataPromises = [];
 
                 myDB.open().then(function (db) {
                     db.transaction('rw', table, operationTable,
                         function () {
                             //Make a clone of the array and create the record to track the online Last Updated date
-                            for(var i=0, countI = objects.length, iRawData,iPrimaryKey;i<countI;i++) {
-                                if((iRawData = objects[i])) {
+                            for (var i=0, countI = objects.length, iRawData, iOperation, iPrimaryKey; i<countI; i++) {
+                                if ((iRawData = objects[i])) {
                                     iPrimaryKey = iRawData[primaryKey];
                                     updateDataPromises.push(table.delete(iPrimaryKey, iRawData));
 
@@ -904,27 +892,25 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                                     iOperation[dataID] = iPrimaryKey;
                                     iOperation[lastModifiedPropertyName] = lastModified;
                                     iOperation[typePropertyName] = type;
-                                    // iOperation[changesPropertyName] = iRawData;
+                                    iOperation[changesPropertyName] = iRawData;
                                     iOperation[operationPropertyName] = operationDeleteName;
                                     iOperation.context = context;
 
-                                    updateDataPromises.push(operationTable.put(iPrimaryKey, iOperation));
+                                    updateDataPromises.push(operationTable.put(iOperation));
                                 }
                             }
                             return Dexie.Promise.all(updateDataPromises);
 
                         }).then(function(value) {
 
-                                //Once this succedded, we need to add our temporary primary keys bookeeping:
-                                //Register potential temporary primaryKeys
-                                self.deleteOfflinePrimaryKeyDependenciesForData(objects);
-
-
+                            //Once this succeeded, we need to add our temporary primary keys bookkeeping:
+                            //Register potential temporary primaryKeys
+                            self.deleteOfflinePrimaryKeyDependenciesForData(objects, type, primaryKey);
                             resolve(clonedObjects);
-                            //console.log(table.name,": updateData for ",objects.length," objects succesfully",value);
+                            //console.log(table.name,": updateData for ",objects.length," objects successfully",value);
                         }).catch(function(e) {
                             reject(e);
-                            // console.log("tableName:failed to addO ffline Data",e)
+                            // console.log("tableName:failed to add Offline Data",e)
                             console.error(table.name,": failed to updateData for ",objects.length," objects with error",e);
                         });
                     }
@@ -962,7 +948,7 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                         //console.log(table.name,": updateData for ",objects.length," objects succesfully",value);
                     }).catch(function(e) {
                         reject(e);
-                        // console.log("tableName:failed to addO ffline Data",e)
+                        // console.log("tableName:failed to add Offline Data",e)
                         console.error(table.name,": failed to updateData for ",objects.length," objects with error",e);
                     });
                 });
@@ -987,7 +973,7 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
         },
         registerOfflineService: {
             value: function(anOfflineService) {
-                this._registeredOfflineServiceByName.set(anOfflineService.name,anOfflineService);
+                this._registeredOfflineServiceByName.set(anOfflineService.name, anOfflineService);
             }
         },
         registeredOfflineServiceNamed: {


### PR DESCRIPTION
A couple of function calls in offline service's deleteData function were
passing incorrect or incomplete arguments.

While creating the delete operations some variables were being declared
using the wrong scope.  This error made some of the property names on
the operation undefined.

The delete operations were not getting the "changes" property assigned.
Without this property the delete operations were not getting read out of
the table properly.

Fixed various syntax issues and removed various unused variables.