### PR TITLE
Use formal Criteria.

### DIFF
--- a/logic/service/data-service.js
+++ b/logic/service/data-service.js
@@ -7,7 +7,7 @@ var Montage = require("montage").Montage,
     DataStream = require("logic/service/data-stream").DataStream,
     DataTrigger = require("logic/service/data-trigger").DataTrigger,
     Map = require("collections/map"),
-    Promise = require("bluebird"),
+    Promise = require("montage/core/promise").Promise,
     Set = require("collections/set"),
     WeakMap = require("collections/weak-map");
 

--- a/logic/service/data-stream.js
+++ b/logic/service/data-stream.js
@@ -1,7 +1,7 @@
 // Note: Bluebird promises are used even if ECMAScript 6 promises are available.
 var DataProvider = require("logic/service/data-provider").DataProvider,
     DataSelector = require("logic/service/data-selector").DataSelector,
-    Promise = require("bluebird");
+    Promise = require("montage/core/promise").Promise;
 
 /**
  * A [DataProvider]{@link DataProvider} whose data is received sequentially.

--- a/logic/service/http-service.js
+++ b/logic/service/http-service.js
@@ -2,7 +2,7 @@ var RawDataService = require("logic/service/raw-data-service").RawDataService,
     DataSelector = require("logic/service/data-selector").DataSelector,
     Enumeration = require("logic/model/enumeration").Enumeration,
     Map = require("collections/map"),
-    Promise = require("bluebird");
+    Promise = require("montage/core/promise").Promise;
 
 /**
  * Superclass for services communicating using HTTP, usually REST services.

--- a/logic/service/offline-service.js
+++ b/logic/service/offline-service.js
@@ -1,7 +1,7 @@
 var RawDataService = require("logic/service/raw-data-service").RawDataService,
     DataStream = require("logic/service/data-stream").DataStream,
     Dexie = require("dexie"),
-    Promise = require("bluebird"),
+    Promise = require("montage/core/promise").Promise,
     uuid = require("montage/core/uuid"),
     DataOrdering = require("logic/model/data-ordering").DataOrdering,
     DESCENDING = DataOrdering.DESCENDING,

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
         "url": "montagestudio/montage-data"
     },
     "dependencies": {
-        "bluebird": "~3.4.x",
         "collections": "~5.0.x",
         "dexie": "~1.4.1",
         "frb":"~3.0.x",


### PR DESCRIPTION
Prevented DataSelector from returning an "empty" criteria, or setting a non-Criteria. Minor comment fix.

Modified OfflineService so that it plays well with the formal Criteria that DataSelectors are now expected to provide.