### PR TITLE
Use formal Criteria

### DIFF
--- a/logic/model/data-selector.js
+++ b/logic/model/data-selector.js
@@ -1,4 +1,5 @@
-var Montage = require("montage").Montage;
+var Montage = require("montage").Montage,
+    Criteria = require("montage/core/criteria").Criteria;
 
 /**
  * Defines the criteria that objects must satisfy to be included in a set of
@@ -30,13 +31,15 @@ exports.DataSelector = exports.DataQuery= Montage.specialize(/** @lends DataSele
      */
     criteria: {
         get: function () {
-            if (!this._criteria) {
-                this._criteria = {};
-            }
             return this._criteria;
         },
         set: function (criteria) {
-            this._criteria = criteria;
+            if (!criteria || criteria instanceof Criteria) {
+                this._criteria = criteria;
+            }
+            else {
+                throw new TypeError("can only set instances of Criteria");
+            }
         }
     },
 
@@ -125,7 +128,7 @@ exports.DataSelector = exports.DataQuery= Montage.specialize(/** @lends DataSele
     /**
      * An object defining a list of expressions to resolve at the same time as the query.
      * expressions are based on the content of results described by criteria. A common
-     * use is to preftch relationships off fetched objects.
+     * use is to prefetch relationships off fetched objects.
      * @type {Array}
      */
 

--- a/logic/service/http-service.js
+++ b/logic/service/http-service.js
@@ -55,7 +55,7 @@ exports.HttpService = RawDataService.specialize(/** @lends HttpService.prototype
             if (!this._getCachedFetchPromise(object, propertyName)) {
                 // Parse arguments.
                 if (arguments.length >= 4) {
-                    selector = DataSelector.withTypeAndCriteria(type, arguments[arguments.length - 1]);
+                    selector = DataSelector.withTypeAndCriteria(type, arguments[arguments.length - 1]);//RDW unclear if there's any special change required here for formal Criteria
                 } else {
                     selector = DataSelector.withTypeAndCriteria(type);
                 }

--- a/logic/service/offline-service.js
+++ b/logic/service/offline-service.js
@@ -347,7 +347,6 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
         value: function (selector, stream) {
             var db = this._db,
                 criteria = selector.criteria,
-                whereProperties = Object.keys(criteria),
                 orderings = selector.orderings,
                 self = this;
 
@@ -361,11 +360,13 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                 db.open().then(function (db) {
                     var table = self.tableNamed(selector.type);
 
-                    if(whereProperties.length) {
+                    var whereProperties = (criteria && criteria.parameters) ? Object.keys(criteria.parameters) : undefined;
+
+                    if(whereProperties && whereProperties.length) {
                         var wherePromise,
                             resultPromise,
                             whereProperty = whereProperties.shift(),
-                            whereValue = criteria[whereProperty];
+                            whereValue = criteria.parameters[whereProperty];
 
                         if(whereProperties.length > 0) {
                                 //db.table1.where("key1").between(8,12).and(function (x) { return x.key2 >= 3 && x.key2 < 18; }).toArray();
@@ -386,7 +387,7 @@ exports.OfflineService = OfflineService = RawDataService.specialize(/** @lends O
                                             .and(function (aRecord) {
                                                 var result = true;
                                                 for(var i=0, iKey, iValue, iKeyMatchValue, iOrValue;(iKey = whereProperties[i]);i++) {
-                                                    iValue = criteria[iKey];
+                                                    iValue = criteria.parameters[iKey];
                                                     iKeyMatchValue = false;
                                                     if(Array.isArray(iValue)) {
                                                         iOrValue = false;


### PR DESCRIPTION
Prevented DataSelector from returning an "empty" criteria, or setting a non-Criteria. Minor comment fix.

Modified OfflineService so that it plays well with the formal Criteria that DataSelectors are now expected to provide.