### PR TITLE
Add request.onerror handling to http-service

### DIFF
--- a/logic/service/http-service.js
+++ b/logic/service/http-service.js
@@ -183,6 +183,7 @@ exports.HttpService = RawDataService.specialize(/** @lends HttpService.prototype
                 } else {
                     request = new XMLHttpRequest();
                     request.onload = function () { resolve(request); };
+                    request.onerror = request.onload;
                     request.open(parsed.body ? "POST" : "GET", parsed.url, true);
                     for (i in parsed.headers) {
                         request.setRequestHeader(i, parsed.headers[i]);
@@ -198,7 +199,7 @@ exports.HttpService = RawDataService.specialize(/** @lends HttpService.prototype
             }).then(function () {
                 // Log a warning for error status responses.
                 // TODO: Reject the promise for error statuses.
-                if (!error && request.status >= 300) {
+                if (!error && (request.status >= 300 || request.status === 0)) {
                     error = new Error("Status " + request.status + " received for REST URL " + parsed.url);
                     console.warn(error);
                 }


### PR DESCRIPTION
HttpService.fetchHttpRawData is only equipped to handle requests that trigger request.onload(). This works for the majority of requests, including most status codes in the 200s, 300s and 400s (at least in my testing) 

However, it was not able to handle requests that fail for other reasons and trigger request.onerror(). For example, Contour requests frequently fail due to CORS restrictions.  This results in errors being swallowed by montage-data and prevents the application from gracefully handling the error. 

At some point, we may want to look at using resolve/reject rather than always resolving. In the meantime, these changes accomplish the goal of supporting on error() without altering the API signature of fetchHttpRawData()